### PR TITLE
Feat: improve error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use the instances workload (cpu) to tune the results.
 - Use a published/versioned crate of boavizta-api-sdk (actual version relies on local sdk).
+- Improve error handling
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
+
+[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -523,6 +529,7 @@ dependencies = [
 name = "cloud-scanner-cli"
 version = "0.0.6"
 dependencies = [
+ "anyhow",
  "aws-config",
  "aws-sdk-cloudwatch",
  "aws-sdk-ec2",

--- a/cloud-scanner-cli/Cargo.toml
+++ b/cloud-scanner-cli/Cargo.toml
@@ -14,6 +14,7 @@ prometheus-client = "*"
 serde = "^1.0"
 serde_derive = "^1.0"
 serde_json = "^1.0"
+anyhow = "1.0.65"
 
 [dependencies.aws-config]
 features = ["rustls"]

--- a/cloud-scanner-cli/src/lib.rs
+++ b/cloud-scanner-cli/src/lib.rs
@@ -11,14 +11,15 @@ mod boavizta_api;
 mod countries;
 mod metrics;
 mod model;
+use anyhow::{Context, Result};
 
 /// Returns a summary (summing/aggregating data where possible) of the scan results.
 pub async fn build_summary(
     instances_with_impacts: &Vec<AwsInstanceWithImpacts>,
     aws_region: &str,
     duration_of_use_hours: f64,
-) -> ScanResultSummary {
-    let number_of_instances_total = u32::try_from(instances_with_impacts.len()).unwrap();
+) -> Result<ScanResultSummary> {
+    let number_of_instances_total = u32::try_from(instances_with_impacts.len())?;
 
     let mut summary = ScanResultSummary {
         number_of_instances_total,
@@ -47,7 +48,7 @@ pub async fn build_summary(
     summary.number_of_instances_not_assessed =
         summary.number_of_instances_total - summary.number_of_instances_assessed;
 
-    summary
+    Ok(summary)
 }
 
 /// Standard scan (using standard/default workload)
@@ -56,8 +57,10 @@ async fn standard_scan(
     tags: &Vec<String>,
     aws_region: &str,
     api_url: &str,
-) -> Vec<AwsInstanceWithImpacts> {
-    let instances = aws_api::list_instances(tags, aws_region).await.unwrap();
+) -> Result<Vec<AwsInstanceWithImpacts>> {
+    let instances = aws_api::list_instances(tags, aws_region)
+        .await
+        .context("Cannot perform standard scan")?;
     let country_code = get_iso_country(aws_region);
 
     let mut instances_with_impacts: Vec<AwsInstanceWithImpacts> = Vec::new();
@@ -70,7 +73,7 @@ async fn standard_scan(
         let value = boavizta_api::get_instance_impacts(instance, usage_cloud, api_url).await;
         instances_with_impacts.push(value);
     }
-    instances_with_impacts
+    Ok(instances_with_impacts)
 }
 
 /// Returns default impacts as json
@@ -79,8 +82,10 @@ pub async fn get_default_impacts(
     tags: &Vec<String>,
     aws_region: &str,
     api_url: &str,
-) -> String {
-    let instances_with_impacts = standard_scan(hours_use_time, tags, aws_region, api_url).await;
+) -> Result<String> {
+    let instances_with_impacts = standard_scan(hours_use_time, tags, aws_region, api_url)
+        .await
+        .context("Cannot perform standard scan")?;
 
     let summary = build_summary(
         &instances_with_impacts,
@@ -91,7 +96,7 @@ pub async fn get_default_impacts(
 
     debug!("Summary: {:#?}", summary);
 
-    serde_json::to_string(&instances_with_impacts).unwrap()
+    Ok(serde_json::to_string(&instances_with_impacts)?)
 }
 
 // Returns default impacts as metrics
@@ -100,19 +105,28 @@ pub async fn get_default_impacts_as_metrics(
     tags: &Vec<String>,
     aws_region: &str,
     api_url: &str,
-) -> String {
-    let instances_with_impacts = standard_scan(hours_use_time, tags, aws_region, api_url).await;
+) -> Result<String> {
+    let instances_with_impacts = standard_scan(hours_use_time, tags, aws_region, api_url)
+        .await
+        .context("Cannot perform standard scan")?;
 
     let summary = build_summary(
         &instances_with_impacts,
         aws_region,
         hours_use_time.to_owned().into(),
     )
-    .await;
+    .await?;
 
     debug!("Summary: {:#?}", summary);
 
-    get_metrics(&summary)
+    let metrics = get_metrics(&summary).with_context(|| {
+        format!(
+            "Unable to get default impacts as metrics for {}",
+            aws_region
+        )
+    })?;
+
+    Ok(metrics)
 }
 
 /// Prints impacts without using use time and default Boavizta impacts
@@ -121,9 +135,10 @@ pub async fn print_default_impacts_as_json(
     tags: &Vec<String>,
     aws_region: &str,
     api_url: &str,
-) {
-    let j = get_default_impacts(hours_use_time, tags, aws_region, api_url).await;
+) -> Result<()> {
+    let j = get_default_impacts(hours_use_time, tags, aws_region, api_url).await?;
     println!("{}", j);
+    Ok(())
 }
 
 /// Prints impacts without using use time and default Boavizta impacts
@@ -132,19 +147,28 @@ pub async fn print_default_impacts_as_metrics(
     tags: &Vec<String>,
     aws_region: &str,
     api_url: &str,
-) {
-    let metrics = get_default_impacts_as_metrics(hours_use_time, tags, aws_region, api_url).await;
+) -> Result<()> {
+    let metrics = get_default_impacts_as_metrics(hours_use_time, tags, aws_region, api_url).await?;
     println!("{}", metrics);
+    Ok(())
 }
 
 /// Prints impacts considering the instance workload / CPU load
-pub async fn print_cpu_load_impacts_as_json(tags: &Vec<String>, aws_region: &str, api_url: &str) {
+pub async fn print_cpu_load_impacts_as_json(
+    tags: &Vec<String>,
+    aws_region: &str,
+    api_url: &str,
+) -> Result<()> {
     warn!("Warning: getting impacts of precise CPU load is not yet implemented, will just display instances and average load of 24 hours");
-    let instances = aws_api::list_instances(tags, aws_region).await.unwrap();
+    let instances = aws_api::list_instances(tags, aws_region)
+        .await
+        .context("Failed to list instances")?;
 
     for instance in &instances {
         let instance_id: &str = instance.instance_id.as_ref().unwrap();
-        let cpu_load = aws_api::get_average_cpu_load_24hrs(instance_id).await;
+        let cpu_load = aws_api::get_average_cpu_load_24hrs(instance_id)
+            .await
+            .context("Failed to get average cpu load")?;
         println!("Instance ID: {}", instance.instance_id().unwrap());
         println!("Type:       {:?}", instance.instance_type().unwrap());
         println!(
@@ -156,11 +180,13 @@ pub async fn print_cpu_load_impacts_as_json(tags: &Vec<String>, aws_region: &str
         println!("Not implemented: query  API at {}", api_url);
         println!();
     }
+    Ok(())
 }
 
 /// List instances as text
-pub async fn show_instances(tags: &Vec<String>, aws_region: &str) {
-    aws_api::display_instances_as_text(tags, aws_region).await;
+pub async fn show_instances(tags: &Vec<String>, aws_region: &str) -> Result<()> {
+    aws_api::display_instances_as_text(tags, aws_region).await?;
+    Ok(())
 }
 
 /// Return current version of the cloud-scanner-cli crate

--- a/cloud-scanner-cli/src/main.rs
+++ b/cloud-scanner-cli/src/main.rs
@@ -1,3 +1,4 @@
+use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 #[macro_use]
 extern crate log;
@@ -72,10 +73,10 @@ fn set_api_url(optional_url: Option<String>) -> String {
 }
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<()> {
     let args = Arguments::parse();
 
-    loggerv::init_with_verbosity(args.verbosity).unwrap();
+    loggerv::init_with_verbosity(args.verbosity).context("Cannot initialize logger")?;
 
     let region = set_region(args.aws_region);
 
@@ -90,7 +91,7 @@ async fn main() {
                     &region,
                     &api_url,
                 )
-                .await
+                .await?
             } else {
                 cloud_scanner_cli::print_default_impacts_as_json(
                     &hours_use_time,
@@ -98,15 +99,16 @@ async fn main() {
                     &region,
                     &api_url,
                 )
-                .await
+                .await?
             }
         }
         SubCommand::Measured {} => {
             cloud_scanner_cli::print_cpu_load_impacts_as_json(&args.filter_tags, &region, &api_url)
-                .await
+                .await?
         }
         SubCommand::ListInstances {} => {
-            cloud_scanner_cli::show_instances(&args.filter_tags, &region).await
+            cloud_scanner_cli::show_instances(&args.filter_tags, &region).await?
         }
     }
+    Ok(())
 }

--- a/cloud-scanner-lambda/src/main.rs
+++ b/cloud-scanner-lambda/src/main.rs
@@ -65,7 +65,8 @@ async fn scan(event: Request) -> Result<impl IntoResponse, Error> {
         aws_region,
         &config.boavizta_api_url,
     )
-    .await;
+    .await
+    .unwrap();
     Ok(response(StatusCode::OK, impacts))
 }
 

--- a/cloud-scanner-lambda/src/metrics.rs
+++ b/cloud-scanner-lambda/src/metrics.rs
@@ -51,7 +51,8 @@ async fn summary(event: Request) -> Result<impl IntoResponse, Error> {
         aws_region,
         &config.boavizta_api_url,
     )
-    .await;
+    .await
+    .unwrap();
     Ok(response(StatusCode::OK, impacts))
 }
 


### PR DESCRIPTION
Use `anyhow` instead of `unwrap()` to let errors bubble up. See issue #17