### PR TITLE
Upgrade to Clap v4.0.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use the instances workload (cpu) to tune the results.
 - Use a published/versioned crate of boavizta-api-sdk (actual version relies on local sdk).
-- Improve error handling
 
 ### Changed
 
 - Update dependencies.
 - Use feature flag on lambda http (support alb and apigw_rest).
 - Clean up code to get rid of Clippy warnings.
+- Improve error handling using Anyhow (see <https://github.com/Boavizta/cloud-scanner/issues/17>)
+- Upgrade to Clap v 4.0.x to provide CLI parsing and help.
 
 ## [0.0.6] - 2022-09-15
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -878,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.49"
+version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bbaead50122b06e9a973ac20bc7445074d99ad9a0a0654934876908a9cec82c"
+checksum = "fd911b35d940d2bd0bea0f9100068e5b97b51a1cbe13d13382f132e0365257a0"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -1011,9 +1011,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.133"
+version = "0.2.134"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f80d65747a3e43d1596c7c5492d95d5edddaabd45a7fcdb02b95f644164966"
+checksum = "329c933548736bc49fd575ee68c89e8be4d260064184389a5b77517cddd99ffb"
 
 [[package]]
 name = "lock_api"
@@ -1247,9 +1247,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "94e2ef8dbfc347b10c094890f778ee2e36ca9bb4262e86dc99cd217e35f3470b"
 dependencies = [
  "unicode-ident",
 ]
@@ -1595,9 +1595,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.100"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52205623b1b0f064a4e71182c3b18ae902267282930c6d5462c91b859668426e"
+checksum = "e90cde112c4b9690b8cbe810cba9ddd8bc1d7472e2cae317b69e9438c1cba7d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1621,18 +1621,18 @@ checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53f98874615aea268107765aa1ed8f6116782501d18e53d08b471733bea6c85"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.35"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8b463991b4eab2d801e724172285ec4195c650e8ec79b149e6c2a8e6dd3f783"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1677,9 +1677,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.21.1"
+version = "1.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0020c875007ad96677dcc890298f4b942882c5d4eb7cc8f439fc3bf813dc9c95"
+checksum = "a9e03c497dc955702ba729190dc4aac6f2a0ce97f913e5b1b5912fc5039d9099"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1687,7 +1687,6 @@ dependencies = [
  "memchr",
  "mio",
  "num_cpus",
- "once_cell",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -2000,9 +1999,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.22.4"
+version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
+checksum = "368bfe657969fb01238bb756d351dcade285e0f6fcbd36dcb23359a5169975be"
 dependencies = [
  "webpki 0.22.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,26 +488,24 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.22"
+version = "4.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
+checksum = "e5e0d0fdd7dc774d433c78c9de5695ca04724beaec6a7d4d13ac6014608f3eaf"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
  "once_cell",
  "strsim",
  "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "3.2.18"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+checksum = "ca689d7434ce44517a12a89456b2be4d1ea1cafcd8f581978c03d45f5a5c12a7"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -518,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
 dependencies = [
  "os_str_bytes",
 ]
@@ -1612,12 +1610,6 @@ checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949517c0cf1bf4ee812e2e07e08ab448e3ae0d23472aee8a06c985f0c8815b16"
 
 [[package]]
 name = "thiserror"

--- a/cloud-scanner-cli/Cargo.toml
+++ b/cloud-scanner-cli/Cargo.toml
@@ -37,7 +37,7 @@ path = "../boavizta-api-sdk"
 
 [dependencies.clap]
 features = ["derive"]
-version = "3.2.21"
+version = "=4.0.5"
 
 [dependencies.tokio]
 features = ["full"]

--- a/cloud-scanner-cli/src/main.rs
+++ b/cloud-scanner-cli/src/main.rs
@@ -11,7 +11,7 @@ struct Arguments {
     #[clap(subcommand)]
     cmd: SubCommand,
     #[clap(short, long)]
-    /// AWS region (default profile region is assumed if not provided)
+    /// AWS region (The default aws profile region is used if not provided)
     aws_region: Option<String>,
     #[clap(short, long)]
     /// Optional Boavizta API URL (if you want to use your own instance)
@@ -19,28 +19,25 @@ struct Arguments {
     #[clap(short = 't', long)]
     /// Filter instances on tags (like tag-key-1=val_1 tag-key_2=val2)
     filter_tags: Vec<String>,
-    // /// Save results to a file (instead of printing json to stdout)
-    // #[clap(short, long, parse(from_os_str))]
-    // out_file: Option<PathBuf>,
+    #[clap(short, long,  action = clap::ArgAction::Count)]
     /// Enable logging, use multiple `v`s to increase verbosity
-    #[clap(short, long, parse(from_occurrences))]
-    verbosity: u64,
-    /// Returns OpenMetrics (Prometheus like) instead of json output
+    verbosity: u8,
+    /// Returns OpenMetrics (Prometheus) instead of json output
     #[clap(short = 'm', long)]
     as_metrics: bool,
 }
 
 #[derive(Subcommand, Debug)]
 enum SubCommand {
-    /// get Average (standard) impacts for a given usage duration
+    /// Get Average (standard) impacts for a given usage duration (without considering cpu use)
     Standard {
         #[clap(short = 'u', long)]
         /// The number of hours of use for which we want to estimate the impacts
         hours_use_time: f32,
     },
-    ///get impacts related to measured instance usage: depending on usage rate (use instance workload),
+    ///Get impacts related to instances usage rate (take into account instance cpu  use)
     Measured {},
-    ///just list instances and their metadata (without impacts)
+    ///Just list instances and their metadata (without impacts)
     ListInstances {},
 }
 
@@ -76,7 +73,7 @@ fn set_api_url(optional_url: Option<String>) -> String {
 async fn main() -> Result<()> {
     let args = Arguments::parse();
 
-    loggerv::init_with_verbosity(args.verbosity).context("Cannot initialize logger")?;
+    loggerv::init_with_verbosity(args.verbosity.into()).context("Cannot initialize logger")?;
 
     let region = set_region(args.aws_region);
 


### PR DESCRIPTION
- Upgrade to Clap v 4.0.x to provide CLI parsing and help.
- Other minor dependencies update.