### PR TITLE
fix: podman-compose does not find images of docker-compose file.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     image: ghcr.io/boavizta/cloud-scanner-cli:latest
     command: 
       - -b http://boavizta_api:5000
-      - -vvv
+      - -vv
       - serve
     environment:
       - AWS_PROFILE=${AWS_PROFILE}
@@ -25,7 +25,7 @@ services:
   grafana:
     container_name: "grafana_boa"
     hostname: grafana
-    image: grafana/grafana
+    image: docker.io/grafana/grafana
     ports:
       - "3001:3000"
     volumes:
@@ -40,7 +40,7 @@ services:
   prometheus:
     container_name: "prometheus_boa"
     hostname: prometheus
-    image: prom/prometheus
+    image: docker.io/prom/prometheus
     volumes:
       - ./dashboard-config/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
     ports:


### PR DESCRIPTION
- Use fully qualified image names. Closes #165 .
- Reduce logs verbosity to -vv.