### PR TITLE
Use latest Boavizta API sdk v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased (DEV branch)
 
-N/A
+### Changed
+
+- Use new Boavizta API SDK for API v0.2.2 and use new API routes (following deprecation of AWS specific URLs). [Upgrade  to stable Boavizta API v0.2.x SDK · Issue #243 · Boavizta/cloud-scanner](https://github.com/Boavizta/cloud-scanner/issues/243) and [Update SDK for boaviztapi v2.x · Issue #4 · Boavizta/boaviztapi-sdk-rust](https://github.com/Boavizta/boaviztapi-sdk-rust/issues/4)
+- Doc: add aws command to list/start/stop instances in the _testing_ chapter of the doc.
 
 ## [0.2.3]-2023-03-13 - Douala release 🌴
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "boavizta_api_sdk"
-version = "0.2.2-alpha2.openapi-generator"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "696e7992c59a1c2657188cf9e5f4dd0c0608c5731ec03d8c310f1e2566c08671"
+checksum = "c0bf0babad628d97e393c6ae1907d446e1140f1826e4c447b022578c16766955"
 dependencies = [
  "reqwest",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -550,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "boavizta_api_sdk"
-version = "0.2.0-alpha.2"
+version = "0.2.2-alpha2.openapi-generator"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5879f50b84ae02f28158af5e612cd08886cf25ef422064837c3802f4ad8178c8"
+checksum = "696e7992c59a1c2657188cf9e5f4dd0c0608c5731ec03d8c310f1e2566c08671"
 dependencies = [
  "reqwest",
  "serde",
@@ -664,7 +664,7 @@ dependencies = [
 
 [[package]]
 name = "cloud-scanner-cli"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/cloud-scanner-cli/Cargo.toml
+++ b/cloud-scanner-cli/Cargo.toml
@@ -2,9 +2,9 @@
 authors = ["boavizta.org", "Olivier de Meringo <demeringo@gmail.com>"]
 edition = "2021"
 name = "cloud-scanner-cli"
-version = "0.2.3"
+version = "0.2.4"
 [dependencies]
-boavizta_api_sdk = "0.2.0-alpha.2"
+boavizta_api_sdk = "0.2.2-alpha2.openapi-generator"
 aws-types = "0.54.1"
 chrono = "^0.4"
 isocountry = "^0.3"

--- a/cloud-scanner-cli/Cargo.toml
+++ b/cloud-scanner-cli/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2021"
 name = "cloud-scanner-cli"
 version = "0.2.4"
 [dependencies]
-boavizta_api_sdk = "0.2.2-alpha2.openapi-generator"
+boavizta_api_sdk = "0.2.2"
 aws-types = "0.54.1"
 chrono = "^0.4"
 isocountry = "^0.3"

--- a/cloud-scanner-cli/src/aws_inventory.rs
+++ b/cloud-scanner-cli/src/aws_inventory.rs
@@ -201,6 +201,7 @@ impl CloudInventory for AwsInventory {
             };
 
             let cs = CloudResource {
+                provider: String::from("aws"),
                 id: instance_id,
                 location: location.clone(),
                 resource_type: instance.instance_type().unwrap().as_str().to_owned(),
@@ -272,7 +273,8 @@ mod tests {
         let datapoints = res.datapoints.unwrap();
         assert!(
             0 < datapoints.len() && datapoints.len() < 3,
-            "Stange number of datapoint returned. I was expecting 1 or 2  but got {} .\n {:#?}",
+            "Strange number of datapoint returned for instance {}, is it really up ?. I was expecting 1 or 2  but got {} .\n {:#?}",
+            &RUNNING_INSTANCE_ID,
             datapoints.len(),
             datapoints
         )
@@ -314,7 +316,11 @@ mod tests {
             .get_average_cpu(&RUNNING_INSTANCE_ID)
             .await
             .unwrap();
-        assert_ne!(0 as f64, avg_cpu_load);
+        assert_ne!(
+            0 as f64, avg_cpu_load,
+            "CPU load of instance {} is zero, is it really running ?",
+            &RUNNING_INSTANCE_ID
+        );
         println!("{:#?}", avg_cpu_load);
         assert!((0 as f64) < avg_cpu_load);
         assert!((100 as f64) > avg_cpu_load);

--- a/cloud-scanner-cli/src/cloud_resource.rs
+++ b/cloud-scanner-cli/src/cloud_resource.rs
@@ -6,6 +6,7 @@ use std::{collections::HashMap, fmt};
 ///  A cloud resource (could be an instance, function or any other resource)
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CloudResource {
+    pub provider: String,
     pub id: String,
     pub location: UsageLocation,
     pub resource_type: String,
@@ -104,6 +105,7 @@ mod tests {
     #[test]
     pub fn a_cloud_resource_can_be_displayed() {
         let instance1: CloudResource = CloudResource {
+            provider: String::from("aws"),
             id: "inst-1".to_string(),
             location: UsageLocation::from("eu-west-1"),
             resource_type: "t2.fictive".to_string(),
@@ -111,12 +113,13 @@ mod tests {
             tags: Vec::new(),
         };
 
-        assert_eq!("CloudResource { id: \"inst-1\", location: UsageLocation { aws_region: \"eu-west-1\", iso_country_code: \"IRL\" }, resource_type: \"t2.fictive\", usage: None, tags: [] }", format!("{:?}", instance1));
+        assert_eq!("CloudResource { provider: \"aws\", id: \"inst-1\", location: UsageLocation { aws_region: \"eu-west-1\", iso_country_code: \"IRL\" }, resource_type: \"t2.fictive\", usage: None, tags: [] }", format!("{:?}", instance1));
     }
 
     #[test]
     pub fn a_cloud_resource_without_usage_data_is_allowed() {
         let instance1: CloudResource = CloudResource {
+            provider: String::from("aws"),
             id: "inst-1".to_string(),
             location: UsageLocation::from("eu-west-1"),
             resource_type: "t2.fictive".to_string(),
@@ -156,6 +159,7 @@ mod tests {
         });
 
         let instance1: CloudResource = CloudResource {
+            provider: String::from("aws"),
             id: "inst-1".to_string(),
             location: UsageLocation::from("eu-west-1"),
             resource_type: "t2.fictive".to_string(),

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -26,3 +26,4 @@
 - [Output data](reference/output-data.md)
 - [Serverless design](reference/serverless-design.md)
 - [Limitations](reference/limits.md)
+- [Unit tests](reference/testing.md)

--- a/docs/src/reference/testing.md
+++ b/docs/src/reference/testing.md
@@ -1,0 +1,19 @@
+# Testing
+
+Whne launched with `cargo test -- --include-ignored` some the unit tests require a specific instance to run (when launched ).
+
+> These integration tests requiere specific instance to be up and running to pass. This means they are tied to a specific cloud account.
+
+Commands to start or stop instances:
+
+```sh
+# List instance state
+aws ec2 describe-instance-status --include-all-instances --filters Name=instance-state-name,Values='*' --query 'InstanceStatuses[*].{InstanceId: InstanceId, State: InstanceState.Name}' --ouptut table
+
+# start instance 
+aws ec2 start-instances --instance-id i-03c8f84a6318a8186
+
+# stop instance
+aws ec2 stop-instances --instance-id i-03c8f84a6318a8186
+
+``` 


### PR DESCRIPTION
Use latest Boavizta API sdk v0.2.2 and migrate to new API URL's.

Closes #243 