### PR TITLE
feat: support Boavizta API 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _This paragraph may describe WIP/unreleased features. They are merged to main branch but not tagged._
 
+## [2.0.3]-2024-01-17
+
 - [Use Boavizta API v1.2.0 · Issue #416 · Boavizta/cloud-scanner](https://github.com/Boavizta/cloud-scanner/issues/416)
 
 ## [2.0.2]-2024-01-17
@@ -19,7 +21,7 @@ _This paragraph may describe WIP/unreleased features. They are merged to main br
 
 ### Changed
 
-- Use latest realeased version of Rust client for Boavizta API v1.0.1
+- Use latest released version of Rust client for Boavizta API v1.0.1
 
 ## [2.0.1]-2024-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _This paragraph may describe WIP/unreleased features. They are merged to main branch but not tagged._
 
+- [Use Boavizta API v1.2.0 · Issue #416 · Boavizta/cloud-scanner](https://github.com/Boavizta/cloud-scanner/issues/416)
+
 ## [2.0.2]-2024-01-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -624,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "boavizta_api_sdk"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fa0b72ca37b926d3af5417a39dcc9b78ef08cab8bc5a012a2f4c8e980728821"
+checksum = "fa67633b559c09b4fa85edb0cb076fc426b221f2d4afd89b9d4ef8139b0c6736"
 dependencies = [
  "reqwest",
  "serde",
@@ -738,7 +738,7 @@ checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "cloud-scanner-cli"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -766,7 +766,7 @@ dependencies = [
 
 [[package]]
 name = "cloud-scanner-lambda"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "cloud-scanner-cli",
  "envy",

--- a/cloud-scanner-cli/Cargo.toml
+++ b/cloud-scanner-cli/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["boavizta.org", "Olivier de Meringo <demeringo@gmail.com>"]
 edition = "2021"
 name = "cloud-scanner-cli"
-version = "2.0.2"
+version = "2.0.3"
 
 [dependencies]
 chrono = "^0.4"
@@ -24,7 +24,7 @@ rocket_okapi = { version = "0.8.0", features = ["swagger", "rapidoc"] }
 aws-types = "1"
 
 [dependencies.boavizta_api_sdk]
-version = "1.1.0"
+version = "1.2.0"
 # path = "../../boaviztapi-sdk-rust"
 
 [dependencies.aws-config]

--- a/cloud-scanner-lambda/Cargo.toml
+++ b/cloud-scanner-lambda/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["boavizta.org", "Olivier de Meringo <demeringo@gmail.com>"]
 edition = "2021"
 name = "cloud-scanner-lambda"
-version = "2.0.2"
+version = "2.0.3"
 [[bin]]
 name = "bootstrap-scan"
 path = "src/main.rs"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
   boavizta_api:
     container_name: "boavizta_api"
     hostname: boavizta
-    image:  ghcr.io/boavizta/boaviztapi:1.1.0
+    image:  ghcr.io/boavizta/boaviztapi:1.2.0
     ports:
       - "5000:5000"
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   cloud_scanner:
     container_name: "cloud_scanner_boa"
     hostname: cloud_scanner
-    image: ghcr.io/boavizta/cloud-scanner-cli:2.0.2
+    image: ghcr.io/boavizta/cloud-scanner-cli:2.0.3
     command: 
       - -b http://boavizta_api:5000
       - -vv
@@ -55,7 +55,7 @@ services:
   boavizta_api:
     container_name: "boavizta_api"
     hostname: boavizta
-    image:  ghcr.io/boavizta/boaviztapi:1.2.0
+    image:  ghcr.io/boavizta/boaviztapi:1.2.2
     ports:
       - "5000:5000"
     networks:


### PR DESCRIPTION
Draft PR

This is mostly working (tested with the dev api).

But we need to await publication of API 1.2.0 docker image to 
- [x] test the docker compose (verify api image tag exists) 
- [x] update the changelog
