### PR TITLE
fix: use stable public Boavizta API URL by default.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 _This paragraph may describe WIP/unreleased features. They are merged to main branch but not tagged._
 
+- [Release 2.0.3 uses dev Boavizta API URL instead of stable · Issue #425 · Boavizta/cloud-scanner](https://github.com/Boavizta/cloud-scanner/issues/425)
+
 ## [2.0.3]-2024-01-17
 
 - [Use Boavizta API v1.2.0 · Issue #416 · Boavizta/cloud-scanner](https://github.com/Boavizta/cloud-scanner/issues/416)

--- a/cloud-scanner-cli/src/main.rs
+++ b/cloud-scanner-cli/src/main.rs
@@ -80,7 +80,7 @@ fn set_api_url(optional_url: Option<String>) -> String {
             url_arg
         }
         None => {
-            let default_url = "https://dev.api.boavizta.org".to_string();
+            let default_url = "https://api.boavizta.org".to_string();
             warn!("Using default API at:  {}", default_url);
             default_url
         }


### PR DESCRIPTION
Closes #425 