### PR TITLE
Add -summary option to estimate command 

### DIFF
--- a/cloud-scanner-cli/src/lib.rs
+++ b/cloud-scanner-cli/src/lib.rs
@@ -82,7 +82,7 @@ pub async fn get_impacts_as_json_string(
         let summary: ImpactsSummary = ImpactsSummary::new(
             String::from(aws_region),
             usage_location.iso_country_code,
-            inventory_with_impacts.clone(),
+            &inventory_with_impacts.clone(),
             (*use_duration_hours).into(),
         );
 

--- a/cloud-scanner-cli/src/main.rs
+++ b/cloud-scanner-cli/src/main.rs
@@ -47,6 +47,10 @@ enum SubCommand {
         /// Returns results as OpenMetrics (Prometheus) instead of json
         #[arg(short = 'm', long)]
         as_metrics: bool,
+
+        /// Returns only the summary of the impacts as json
+        #[arg(short = 's', long)]
+        summary_only: bool,
     },
     /// List instances and  their average cpu load for the last 5 minutes (without returning impacts)
     Inventory {
@@ -103,6 +107,7 @@ async fn main() -> Result<()> {
             include_block_storage,
             output_verbose_json,
             as_metrics,
+            summary_only,
         } => {
             if as_metrics {
                 cloud_scanner_cli::print_default_impacts_as_metrics(
@@ -121,6 +126,7 @@ async fn main() -> Result<()> {
                     &api_url,
                     output_verbose_json,
                     include_block_storage,
+                    summary_only,
                 )
                 .await?
             }


### PR DESCRIPTION
to return the summary of impacts as JSON. See #456

Tested by running `cargo run -- -a us-east-1 estimate --use-duration-hours 1 -s`