### PR TITLE
feat: return API and scanner versions in the json inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 _This paragraph may describe WIP/unreleased features. They are merged to main branch but not tagged._
+- [Return API and scanner version in the json output](https://github.com/Boavizta/cloud-scanner/issues/265)
 - [Upgrade to BoaviztAPI 1.3.3 · Issue #633 · Boavizta/cloud-scanner](https://github.com/Boavizta/cloud-scanner/issues/633)
 - [chore(deps): bump serde_json from 1.0.132 to 1.0.133](https://github.com/Boavizta/cloud-scanner/issues/#614)
 - [chore(deps): bump tokio from 1.41.1 to 1.42.0](https://github.com/Boavizta/cloud-scanner/issues/#628)

--- a/cloud-scanner-cli/src/lib.rs
+++ b/cloud-scanner-cli/src/lib.rs
@@ -157,28 +157,40 @@ pub fn get_version() -> String {
     format!("{}.{}.{}", MAJOR, MINOR, PATCH)
 }
 
-#[tokio::test]
-async fn summary_has_to_contain_a_usage_duration() {
-    use crate::impact_provider::CloudResourceWithImpacts;
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::EstimationMetadata;
 
-    let resources: Vec<CloudResourceWithImpacts> = Vec::new();
+    #[tokio::test]
+    async fn summary_has_to_contain_a_usage_duration() {
+        use crate::impact_provider::CloudResourceWithImpacts;
 
-    let resources_with_impacts: EstimatedInventory = EstimatedInventory {
-        impacting_resources: resources,
-        execution_statistics: None,
-    };
+        let resources: Vec<CloudResourceWithImpacts> = Vec::new();
 
-    let usage_duration_hours = 1.5;
+        let resources_with_impacts: EstimatedInventory = EstimatedInventory {
+            impacting_resources: resources,
+            metadata: EstimationMetadata {
+                description: None,
+                boavizta_api_version: Some("v1.2.3".to_owned()),
+                cloud_scanner_version: Some("acb".to_owned()),
+                estimation_date: None,
+                execution_statistics: None,
+            },
+        };
 
-    let summary: ImpactsSummary = ImpactsSummary::new(
-        String::from("eu-west-1"),
-        String::from("IRL"),
-        &resources_with_impacts,
-        usage_duration_hours,
-    );
+        let usage_duration_hours = 1.5;
 
-    assert_eq!(
-        summary.duration_of_use_hours, usage_duration_hours,
-        "Duration of summary should match"
-    );
+        let summary: ImpactsSummary = ImpactsSummary::new(
+            String::from("eu-west-1"),
+            String::from("IRL"),
+            &resources_with_impacts,
+            usage_duration_hours,
+        );
+
+        assert_eq!(
+            summary.duration_of_use_hours, usage_duration_hours,
+            "Duration of summary should match"
+        );
+    }
 }

--- a/cloud-scanner-cli/src/metric_exporter.rs
+++ b/cloud-scanner-cli/src/metric_exporter.rs
@@ -379,7 +379,8 @@ mod tests {
     use super::*;
     use crate::impact_provider::ImpactsValues;
     use crate::model::{
-        CloudProvider, CloudResource, CloudResourceTag, InstanceUsage, StorageUsage,
+        CloudProvider, CloudResource, CloudResourceTag, EstimationMetadata, InstanceUsage,
+        StorageUsage,
     };
     use crate::usage_location::UsageLocation;
 
@@ -476,8 +477,14 @@ boavizta_gwp_use_kgco2eq{awsregion="eu-west-1",country="IRL"} 0.6
         };
 
         let estimated_inventory: EstimatedInventory = EstimatedInventory {
+            metadata: EstimationMetadata {
+                description: None,
+                boavizta_api_version: Some("v1.2.3".to_owned()),
+                cloud_scanner_version: Some("acb".to_owned()),
+                estimation_date: None,
+                execution_statistics: None,
+            },
             impacting_resources: vec![cloud_resource_with_impacts],
-            execution_statistics: None,
         };
 
         let summary = ImpactsSummary::new(
@@ -587,8 +594,14 @@ boavizta_resource_cpu_load{awsregion="eu-west-3",country="FRA",resource_type="In
         };
 
         let estimated_inventory: EstimatedInventory = EstimatedInventory {
+            metadata: EstimationMetadata {
+                description: None,
+                boavizta_api_version: Some("v1.2.3".to_owned()),
+                cloud_scanner_version: Some("acb".to_owned()),
+                estimation_date: None,
+                execution_statistics: None,
+            },
             impacting_resources: vec![cloud_resource_with_impacts],
-            execution_statistics: None,
         };
 
         let summary = ImpactsSummary::new(

--- a/cloud-scanner-cli/src/model.rs
+++ b/cloud-scanner-cli/src/model.rs
@@ -66,7 +66,23 @@ pub async fn load_inventory_fom_json(json_inventory: &str) -> anyhow::Result<Inv
 #[derive(Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct EstimatedInventory {
+    pub metadata: EstimationMetadata,
     pub impacting_resources: Vec<CloudResourceWithImpacts>,
+}
+
+/// Details about the estimation
+#[derive(Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct EstimationMetadata {
+    /// The date when the estimation was generated
+    pub estimation_date: Option<DateTime<Utc>>,
+    /// A free text description of the estimation
+    pub description: Option<String>,
+    /// The version of the cloud scanner that provided the estimation
+    pub cloud_scanner_version: Option<String>,
+    /// The version of the Boavizta api that provided the estimation
+    pub boavizta_api_version: Option<String>,
+    /// Statistics about program execution
     pub execution_statistics: Option<ExecutionStatistics>,
 }
 

--- a/cloud-scanner-cli/src/usage_location.rs
+++ b/cloud-scanner-cli/src/usage_location.rs
@@ -73,7 +73,7 @@ fn get_country_from_aws_region(aws_region: &str) -> Result<String, RegionError> 
                 "Unsupported region: unable to match aws region [{}] to country code",
                 aws_region
             );
-            return Err(RegionError::UnsupportedRegion(String::from(aws_region)));
+            Err(RegionError::UnsupportedRegion(String::from(aws_region)))
         }
     }
 }

--- a/docs/src/reference/openapi.json
+++ b/docs/src/reference/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "cloud-scanner-cli",
-    "version": "2.0.5"
+    "version": "3.2.0-SNAPSHOT"
   },
   "paths": {
     "/metrics": {
@@ -239,7 +239,7 @@
   "components": {
     "schemas": {
       "Inventory": {
-        "description": "Inventory: a list of resources",
+        "description": "A list of cloud resources and metadata that describes the inventory itself",
         "type": "object",
         "required": [
           "metadata",
@@ -254,8 +254,31 @@
             "items": {
               "$ref": "#/components/schemas/CloudResource"
             }
+          }
+        }
+      },
+      "InventoryMetadata": {
+        "description": "Details about the inventory",
+        "type": "object",
+        "properties": {
+          "inventory_date": {
+            "description": "The date when the inventory was generated",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "description": {
+            "description": "A free text description of the inventory",
+            "type": "string",
+            "nullable": true
+          },
+          "cloud_scanner_version": {
+            "description": "The version of the cloud scanner that generated the inventory",
+            "type": "string",
+            "nullable": true
           },
           "execution_statistics": {
+            "description": "Statistics about program execution",
             "allOf": [
               {
                 "$ref": "#/components/schemas/ExecutionStatistics"
@@ -265,23 +288,47 @@
           }
         }
       },
-      "InventoryMetadata": {
-        "description": "Details about the inventory",
+      "ExecutionStatistics": {
+        "description": "Statistics about program execution",
         "type": "object",
+        "required": [
+          "impact_estimation_duration",
+          "inventory_duration",
+          "total_duration"
+        ],
         "properties": {
-          "inventory_date": {
-            "type": "string",
-            "format": "date-time",
-            "nullable": true
+          "inventory_duration": {
+            "$ref": "#/components/schemas/Duration"
           },
-          "description": {
-            "type": "string",
-            "nullable": true
+          "impact_estimation_duration": {
+            "$ref": "#/components/schemas/Duration"
+          },
+          "total_duration": {
+            "$ref": "#/components/schemas/Duration"
+          }
+        }
+      },
+      "Duration": {
+        "type": "object",
+        "required": [
+          "nanos",
+          "secs"
+        ],
+        "properties": {
+          "secs": {
+            "type": "integer",
+            "format": "uint64",
+            "minimum": 0.0
+          },
+          "nanos": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
           }
         }
       },
       "CloudResource": {
-        "description": "A cloud resource (could be an instance, function or any other resource)",
+        "description": "A cloud resource (could be an instance, block storage or any other resource)",
         "type": "object",
         "required": [
           "id",
@@ -298,7 +345,12 @@
             "type": "string"
           },
           "location": {
-            "$ref": "#/components/schemas/UsageLocation"
+            "description": "The location where cloud resources are running.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/UsageLocation"
+              }
+            ]
           },
           "resource_details": {
             "$ref": "#/components/schemas/ResourceDetails"
@@ -471,59 +523,52 @@
           }
         }
       },
-      "ExecutionStatistics": {
-        "description": "Statistics about program execution",
-        "type": "object",
-        "required": [
-          "impact_estimation_duration",
-          "inventory_duration",
-          "total_duration"
-        ],
-        "properties": {
-          "inventory_duration": {
-            "$ref": "#/components/schemas/Duration"
-          },
-          "impact_estimation_duration": {
-            "$ref": "#/components/schemas/Duration"
-          },
-          "total_duration": {
-            "$ref": "#/components/schemas/Duration"
-          }
-        }
-      },
-      "Duration": {
-        "type": "object",
-        "required": [
-          "nanos",
-          "secs"
-        ],
-        "properties": {
-          "secs": {
-            "type": "integer",
-            "format": "uint64",
-            "minimum": 0.0
-          },
-          "nanos": {
-            "type": "integer",
-            "format": "uint32",
-            "minimum": 0.0
-          }
-        }
-      },
       "EstimatedInventory": {
         "description": "An estimated inventory: impacting resources with their estimated impacts",
         "type": "object",
         "required": [
-          "impacting_resources"
+          "impacting_resources",
+          "metadata"
         ],
         "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/EstimationMetadata"
+          },
           "impacting_resources": {
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/CloudResourceWithImpacts"
             }
+          }
+        }
+      },
+      "EstimationMetadata": {
+        "description": "Details about the estimation",
+        "type": "object",
+        "properties": {
+          "estimation_date": {
+            "description": "The date when the estimation was generated",
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "description": {
+            "description": "A free text description of the estimation",
+            "type": "string",
+            "nullable": true
+          },
+          "cloud_scanner_version": {
+            "description": "The version of the cloud scanner that provided the estimation",
+            "type": "string",
+            "nullable": true
+          },
+          "boavizta_api_version": {
+            "description": "The version of the Boavizta api that provided the estimation",
+            "type": "string",
+            "nullable": true
           },
           "execution_statistics": {
+            "description": "Statistics about program execution",
             "allOf": [
               {
                 "$ref": "#/components/schemas/ExecutionStatistics"


### PR DESCRIPTION
Closes #265 by adding metadata to the inventory output in json format.

``` json
{
  "metadata": {
    "estimation_date": "2024-12-14T22:47:25.783194010Z",
    "description": "Estimation using Boavizta API",
    "cloud_scanner_version": "3.2.0",
    "boavizta_api_version": "1.3.6",
    "execution_statistics": {
      "inventory_duration": {
        "secs": 0,
        "nanos": 296360816
      },
      "impact_estimation_duration": {
        "secs": 0,
        "nanos": 1937
      },
      "total_duration": {
        "secs": 0,
        "nanos": 296362753
      }
    }
  },
  "impacting_resources": []
}

```