### PR TITLE
feat: Return API and scanner version in the metrics output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 _This paragraph may describe WIP/unreleased features. They are merged to main branch but not tagged._
+- [Return API and scanner version in the metrics output](https://github.com/Boavizta/cloud-scanner/issues/266)
 - [Upgrade version of BoaviztAPI to 1.3.7 and adjust tests accordingly](https://github.com/Boavizta/cloud-scanner/issues/643)
 - [Return API and scanner version in the json output](https://github.com/Boavizta/cloud-scanner/issues/265)
 - [Upgrade to BoaviztAPI 1.3.3 · Issue #633 · Boavizta/cloud-scanner](https://github.com/Boavizta/cloud-scanner/issues/633)


### PR DESCRIPTION
Two new labels are added to all the metrics: `cloud_scanner_version` and ` boaviztapi_version`.

Per example:
```
# HELP boavizta_gwp_use_kgco2eq Global Warming Potential of use.
# TYPE boavizta_gwp_use_kgco2eq gauge
boavizta_gwp_use_kgco2eq{awsregion="eu-west-3",country="FRA",cloud_scanner_version="4.5.6",boaviztapi_version="v1.2.3"} 0.6
```
