### PR TITLE
AWS permission cloudwatch:DescribeAlarm does not exist (anymore ?) cloudwatch:DescribeAlarms does

### DIFF
--- a/docs/src/how-to/passing-aws-credentials.md
+++ b/docs/src/how-to/passing-aws-credentials.md
@@ -10,7 +10,7 @@ The minimal set of permissions to perform inventory of resources (and query CPU 
 
 - ec2:DescribeInstances
 - cloudwatch:GetMetricStatistics
-- cloudwatch:DescribeAlarm
+- cloudwatch:DescribeAlarms
 
 You could also restricts permissions to a specific set of instances or resources.
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -18,7 +18,7 @@ provider:
           Action: "cloudwatch:GetMetricStatistics"
           Resource: "*"
         - Effect: Allow
-          Action: "cloudwatch:DescribeAlarm"
+          Action: "cloudwatch:DescribeAlarms"
           Resource: "*"
   environment:
     BOAVIZTA_API_URL: ${env:BOAVIZTA_API_URL}


### PR DESCRIPTION
While following the wiki, I could not find the permission `cloudwatch:DescribeAlarm` but `cloudwatch:DescribeAlarms` (with an `s` at the end) does exist, so I think it might have changed name.

(I did not test `serverless.yml` as I am not that familiar with deploying serveless applications and not completely sure I would not be billed by AWS for doing so)